### PR TITLE
⚙️ Added Dependencies ⚙️

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,6 +6,11 @@ game 'gta5'
 version '1.0.0'
 lua54 'yes'
 
+dependencies {
+    '/server:5848',
+    '/onesync',
+}
+
 -- Remove the following lines if you would like to use the SQL keybinds. Requires oxmysql.
 
 --#region oxmysql


### PR DESCRIPTION
It is important to keep your server artifacts updated at least once a month. To use RPEmotes, server owners must have onesync enabled and have the latest recommended server artifacts. Currently, this is 5848.